### PR TITLE
Fix typo: authenticated-signed-write -> authenticated-signed-writes

### DIFF
--- a/bluez-async/CHANGELOG.md
+++ b/bluez-async/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bugfixes
+
+- Fixed bug with `authenticated-signed-writes` characteristic flag not being recognised due to typo.
+
 ## 0.5.0
 
 ### Breaking changes

--- a/bluez-async/src/characteristic.rs
+++ b/bluez-async/src/characteristic.rs
@@ -96,7 +96,7 @@ impl TryFrom<Vec<String>> for CharacteristicFlags {
                 "write" => Self::WRITE,
                 "notify" => Self::NOTIFY,
                 "indicate" => Self::INDICATE,
-                "authenticated-signed-write" => Self::SIGNED_WRITE,
+                "authenticated-signed-writes" => Self::SIGNED_WRITE,
                 "extended-properties" => Self::EXTENDED_PROPERTIES,
                 "reliable-write" => Self::RELIABLE_WRITE,
                 "writable-auxiliaries" => Self::WRITABLE_AUXILIARIES,


### PR DESCRIPTION
Otherwise 'characteristics' example fails with following error:

Devices:
F7:EB:ED:XX:XX:XX: hci0/dev_F7_EB_ED_XX_XX_XX
Service 0xffc0 (primary): hci0/dev_F7_EB_ED_XX_XX_XX/service0006
Error: Invalid characteristic flag "authenticated-signed-writes"