### PR TITLE
Add rt feature for tokio.

### DIFF
--- a/bluez-async/Cargo.toml
+++ b/bluez-async/Cargo.toml
@@ -22,7 +22,7 @@ serde = "1.0.118"
 serde_derive = "1.0.118"
 serde-xml-rs = "0.5.0"
 thiserror = "1.0.23"
-tokio = "1.0.1"
+tokio = { version = "1.0.1", features = ["rt"] }
 uuid = "0.8.1"
 
 [dev-dependencies]


### PR DESCRIPTION
It is needed for `JoinError` and `spawn`.

Fixes #15.