### PR TITLE
Prepare for bluez-async 0.5.2 release.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bluez-async"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "async-trait",
  "bitflags",

--- a/bluez-async/CHANGELOG.md
+++ b/bluez-async/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.5.2
+
+### Bugfixes
+
+- Fixed `tokio` dependency to include `rt` feature.
+
 ## 0.5.1
 
 ### Bugfixes

--- a/bluez-async/Cargo.toml
+++ b/bluez-async/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bluez-async"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Andrew Walbran <qwandor@google.com>", "David Laban <alsuren@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
This has the fix for #15.