### PR TITLE
Log error rather than printing it.

### DIFF
--- a/bluez-async/CHANGELOG.md
+++ b/bluez-async/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Bugfixes
+
+- Fixed `start_discovery` and `start_discovery_with_filter` to log errors rather than printing them
+  to stdout.
+
 ## 0.5.2
 
 ### Bugfixes

--- a/bluez-async/src/lib.rs
+++ b/bluez-async/src/lib.rs
@@ -338,7 +338,7 @@ impl BluetoothSession {
             log::trace!("Starting discovery on adapter {}", adapter.id);
             self.start_discovery_on_adapter_with_filter(&adapter.id, discovery_filter)
                 .await
-                .unwrap_or_else(|err| println!("starting discovery failed {:?}", err));
+                .unwrap_or_else(|err| log::error!("starting discovery failed {:?}", err));
         }
         Ok(())
     }


### PR DESCRIPTION
Should fix https://github.com/deviceplug/btleplug/issues/241.