### PR TITLE
Add BluetoothSession::adapter_event_stream method.

### DIFF
--- a/bluez-async/CHANGELOG.md
+++ b/bluez-async/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### New features
+
+- Added `BluetoothSession::adapter_event_stream` method.
+
 ## 0.5.3
 
 ### Bugfixes

--- a/bluez-async/src/adapter.rs
+++ b/bluez-async/src/adapter.rs
@@ -19,6 +19,12 @@ impl AdapterId {
     }
 }
 
+impl From<AdapterId> for Path<'static> {
+    fn from(id: AdapterId) -> Self {
+        id.object_path
+    }
+}
+
 impl Display for AdapterId {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(

--- a/bluez-async/src/lib.rs
+++ b/bluez-async/src/lib.rs
@@ -845,6 +845,15 @@ impl BluetoothSession {
         self.filtered_event_stream(None::<&DeviceId>).await
     }
 
+    /// Get a stream of events for a particular adapter. This includes events for all devices it
+    /// discovers or connects to.
+    pub async fn adapter_event_stream(
+        &self,
+        adapter: &AdapterId,
+    ) -> Result<impl Stream<Item = BluetoothEvent>, BluetoothError> {
+        self.filtered_event_stream(Some(adapter)).await
+    }
+
     /// Get a stream of events for a particular device. This includes events for all its
     /// characteristics.
     pub async fn device_event_stream(


### PR DESCRIPTION
This filters events by adapter, similar to the existing methods to filter by device or characteristic.