### PR TITLE
Bump CI dependencies

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,17 +6,17 @@ on:
   pull_request:
 
 env:
-  dbus-codegen-version: 0.9.1
+  dbus-codegen-version: 0.10.0
 
 jobs:
   generated:
     name: Check that generated files haven't been modified
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Cache dbus-codegen-rust
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/bin/dbus-codegen-rust
@@ -39,6 +39,6 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Format Rust code
         run: cargo fmt --all -- --check

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install dependencies
         run: sudo apt-get install libdbus-1-dev
       - name: Build
@@ -31,11 +31,11 @@ jobs:
     env:
       RUSTC_BOOTSTRAP: 1
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install dependencies
         run: sudo apt-get install libdbus-1-dev
       - name: Install grcov
-        run: curl -L https://github.com/mozilla/grcov/releases/download/v0.8.7/grcov-x86_64-unknown-linux-gnu.tar.bz2 | tar -jxf -
+        run: curl -L https://github.com/mozilla/grcov/releases/download/v0.8.13/grcov-x86_64-unknown-linux-gnu.tar.bz2 | tar -jxf -
       - name: Install llvm-tools
         run: rustup component add llvm-tools-preview
       - name: Build for coverage
@@ -50,7 +50,7 @@ jobs:
       - name: Convert coverage
         run: ./grcov . -s . --binary-path target/debug/ -t lcov --branch --ignore-not-existing -o target/debug/lcov.info
       - name: Upload coverage to codecov.io
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           directory: ./target/debug
           fail_ci_if_error: true

--- a/bluez-generated/src/adapter1.rs
+++ b/bluez-generated/src/adapter1.rs
@@ -30,6 +30,71 @@ pub trait OrgBluezAdapter1 {
     fn modalias(&self) -> nonblock::MethodReply<String>;
 }
 
+pub const ORG_BLUEZ_ADAPTER1_NAME: &str = "org.bluez.Adapter1";
+
+#[derive(Copy, Clone, Debug)]
+pub struct OrgBluezAdapter1Properties<'a>(pub &'a arg::PropMap);
+
+impl<'a> OrgBluezAdapter1Properties<'a> {
+    pub fn from_interfaces(
+        interfaces: &'a ::std::collections::HashMap<String, arg::PropMap>,
+    ) -> Option<Self> {
+        interfaces.get("org.bluez.Adapter1").map(Self)
+    }
+
+    pub fn address(&self) -> Option<&String> {
+        arg::prop_cast(self.0, "Address")
+    }
+
+    pub fn address_type(&self) -> Option<&String> {
+        arg::prop_cast(self.0, "AddressType")
+    }
+
+    pub fn name(&self) -> Option<&String> {
+        arg::prop_cast(self.0, "Name")
+    }
+
+    pub fn alias(&self) -> Option<&String> {
+        arg::prop_cast(self.0, "Alias")
+    }
+
+    pub fn class(&self) -> Option<u32> {
+        arg::prop_cast(self.0, "Class").copied()
+    }
+
+    pub fn powered(&self) -> Option<bool> {
+        arg::prop_cast(self.0, "Powered").copied()
+    }
+
+    pub fn discoverable(&self) -> Option<bool> {
+        arg::prop_cast(self.0, "Discoverable").copied()
+    }
+
+    pub fn discoverable_timeout(&self) -> Option<u32> {
+        arg::prop_cast(self.0, "DiscoverableTimeout").copied()
+    }
+
+    pub fn pairable(&self) -> Option<bool> {
+        arg::prop_cast(self.0, "Pairable").copied()
+    }
+
+    pub fn pairable_timeout(&self) -> Option<u32> {
+        arg::prop_cast(self.0, "PairableTimeout").copied()
+    }
+
+    pub fn discovering(&self) -> Option<bool> {
+        arg::prop_cast(self.0, "Discovering").copied()
+    }
+
+    pub fn uuids(&self) -> Option<&Vec<String>> {
+        arg::prop_cast(self.0, "UUIDs")
+    }
+
+    pub fn modalias(&self) -> Option<&String> {
+        arg::prop_cast(self.0, "Modalias")
+    }
+}
+
 impl<'a, T: nonblock::NonblockReply, C: ::std::ops::Deref<Target = T>> OrgBluezAdapter1
     for nonblock::Proxy<'a, C>
 {
@@ -210,70 +275,5 @@ impl<'a, T: nonblock::NonblockReply, C: ::std::ops::Deref<Target = T>> OrgBluezA
             "PairableTimeout",
             value,
         )
-    }
-}
-
-pub const ORG_BLUEZ_ADAPTER1_NAME: &str = "org.bluez.Adapter1";
-
-#[derive(Copy, Clone, Debug)]
-pub struct OrgBluezAdapter1Properties<'a>(pub &'a arg::PropMap);
-
-impl<'a> OrgBluezAdapter1Properties<'a> {
-    pub fn from_interfaces(
-        interfaces: &'a ::std::collections::HashMap<String, arg::PropMap>,
-    ) -> Option<Self> {
-        interfaces.get("org.bluez.Adapter1").map(Self)
-    }
-
-    pub fn address(&self) -> Option<&String> {
-        arg::prop_cast(self.0, "Address")
-    }
-
-    pub fn address_type(&self) -> Option<&String> {
-        arg::prop_cast(self.0, "AddressType")
-    }
-
-    pub fn name(&self) -> Option<&String> {
-        arg::prop_cast(self.0, "Name")
-    }
-
-    pub fn alias(&self) -> Option<&String> {
-        arg::prop_cast(self.0, "Alias")
-    }
-
-    pub fn class(&self) -> Option<u32> {
-        arg::prop_cast(self.0, "Class").copied()
-    }
-
-    pub fn powered(&self) -> Option<bool> {
-        arg::prop_cast(self.0, "Powered").copied()
-    }
-
-    pub fn discoverable(&self) -> Option<bool> {
-        arg::prop_cast(self.0, "Discoverable").copied()
-    }
-
-    pub fn discoverable_timeout(&self) -> Option<u32> {
-        arg::prop_cast(self.0, "DiscoverableTimeout").copied()
-    }
-
-    pub fn pairable(&self) -> Option<bool> {
-        arg::prop_cast(self.0, "Pairable").copied()
-    }
-
-    pub fn pairable_timeout(&self) -> Option<u32> {
-        arg::prop_cast(self.0, "PairableTimeout").copied()
-    }
-
-    pub fn discovering(&self) -> Option<bool> {
-        arg::prop_cast(self.0, "Discovering").copied()
-    }
-
-    pub fn uuids(&self) -> Option<&Vec<String>> {
-        arg::prop_cast(self.0, "UUIDs")
-    }
-
-    pub fn modalias(&self) -> Option<&String> {
-        arg::prop_cast(self.0, "Modalias")
     }
 }

--- a/bluez-generated/src/agentmanager1.rs
+++ b/bluez-generated/src/agentmanager1.rs
@@ -9,6 +9,8 @@ pub trait OrgBluezAgentManager1 {
     fn request_default_agent(&self, agent: dbus::Path) -> nonblock::MethodReply<()>;
 }
 
+pub const ORG_BLUEZ_AGENT_MANAGER1_NAME: &str = "org.bluez.AgentManager1";
+
 impl<'a, T: nonblock::NonblockReply, C: ::std::ops::Deref<Target = T>> OrgBluezAgentManager1
     for nonblock::Proxy<'a, C>
 {
@@ -28,5 +30,3 @@ impl<'a, T: nonblock::NonblockReply, C: ::std::ops::Deref<Target = T>> OrgBluezA
         self.method_call("org.bluez.AgentManager1", "RequestDefaultAgent", (agent,))
     }
 }
-
-pub const ORG_BLUEZ_AGENT_MANAGER1_NAME: &str = "org.bluez.AgentManager1";

--- a/bluez-generated/src/battery1.rs
+++ b/bluez-generated/src/battery1.rs
@@ -7,18 +7,6 @@ pub trait OrgBluezBattery1 {
     fn percentage(&self) -> nonblock::MethodReply<u8>;
 }
 
-impl<'a, T: nonblock::NonblockReply, C: ::std::ops::Deref<Target = T>> OrgBluezBattery1
-    for nonblock::Proxy<'a, C>
-{
-    fn percentage(&self) -> nonblock::MethodReply<u8> {
-        <Self as nonblock::stdintf::org_freedesktop_dbus::Properties>::get(
-            &self,
-            "org.bluez.Battery1",
-            "Percentage",
-        )
-    }
-}
-
 pub const ORG_BLUEZ_BATTERY1_NAME: &str = "org.bluez.Battery1";
 
 #[derive(Copy, Clone, Debug)]
@@ -33,5 +21,17 @@ impl<'a> OrgBluezBattery1Properties<'a> {
 
     pub fn percentage(&self) -> Option<u8> {
         arg::prop_cast(self.0, "Percentage").copied()
+    }
+}
+
+impl<'a, T: nonblock::NonblockReply, C: ::std::ops::Deref<Target = T>> OrgBluezBattery1
+    for nonblock::Proxy<'a, C>
+{
+    fn percentage(&self) -> nonblock::MethodReply<u8> {
+        <Self as nonblock::stdintf::org_freedesktop_dbus::Properties>::get(
+            &self,
+            "org.bluez.Battery1",
+            "Percentage",
+        )
     }
 }

--- a/bluez-generated/src/device1.rs
+++ b/bluez-generated/src/device1.rs
@@ -39,6 +39,102 @@ pub trait OrgBluezDevice1 {
     fn services_resolved(&self) -> nonblock::MethodReply<bool>;
 }
 
+pub const ORG_BLUEZ_DEVICE1_NAME: &str = "org.bluez.Device1";
+
+#[derive(Copy, Clone, Debug)]
+pub struct OrgBluezDevice1Properties<'a>(pub &'a arg::PropMap);
+
+impl<'a> OrgBluezDevice1Properties<'a> {
+    pub fn from_interfaces(
+        interfaces: &'a ::std::collections::HashMap<String, arg::PropMap>,
+    ) -> Option<Self> {
+        interfaces.get("org.bluez.Device1").map(Self)
+    }
+
+    pub fn address(&self) -> Option<&String> {
+        arg::prop_cast(self.0, "Address")
+    }
+
+    pub fn address_type(&self) -> Option<&String> {
+        arg::prop_cast(self.0, "AddressType")
+    }
+
+    pub fn name(&self) -> Option<&String> {
+        arg::prop_cast(self.0, "Name")
+    }
+
+    pub fn alias(&self) -> Option<&String> {
+        arg::prop_cast(self.0, "Alias")
+    }
+
+    pub fn class(&self) -> Option<u32> {
+        arg::prop_cast(self.0, "Class").copied()
+    }
+
+    pub fn appearance(&self) -> Option<u16> {
+        arg::prop_cast(self.0, "Appearance").copied()
+    }
+
+    pub fn icon(&self) -> Option<&String> {
+        arg::prop_cast(self.0, "Icon")
+    }
+
+    pub fn paired(&self) -> Option<bool> {
+        arg::prop_cast(self.0, "Paired").copied()
+    }
+
+    pub fn trusted(&self) -> Option<bool> {
+        arg::prop_cast(self.0, "Trusted").copied()
+    }
+
+    pub fn blocked(&self) -> Option<bool> {
+        arg::prop_cast(self.0, "Blocked").copied()
+    }
+
+    pub fn legacy_pairing(&self) -> Option<bool> {
+        arg::prop_cast(self.0, "LegacyPairing").copied()
+    }
+
+    pub fn rssi(&self) -> Option<i16> {
+        arg::prop_cast(self.0, "RSSI").copied()
+    }
+
+    pub fn connected(&self) -> Option<bool> {
+        arg::prop_cast(self.0, "Connected").copied()
+    }
+
+    pub fn uuids(&self) -> Option<&Vec<String>> {
+        arg::prop_cast(self.0, "UUIDs")
+    }
+
+    pub fn modalias(&self) -> Option<&String> {
+        arg::prop_cast(self.0, "Modalias")
+    }
+
+    pub fn adapter(&self) -> Option<&dbus::Path<'static>> {
+        arg::prop_cast(self.0, "Adapter")
+    }
+
+    pub fn manufacturer_data(
+        &self,
+    ) -> Option<&::std::collections::HashMap<u16, arg::Variant<Box<dyn arg::RefArg + 'static>>>>
+    {
+        arg::prop_cast(self.0, "ManufacturerData")
+    }
+
+    pub fn service_data(&self) -> Option<&arg::PropMap> {
+        arg::prop_cast(self.0, "ServiceData")
+    }
+
+    pub fn tx_power(&self) -> Option<i16> {
+        arg::prop_cast(self.0, "TxPower").copied()
+    }
+
+    pub fn services_resolved(&self) -> Option<bool> {
+        arg::prop_cast(self.0, "ServicesResolved").copied()
+    }
+}
+
 impl<'a, T: nonblock::NonblockReply, C: ::std::ops::Deref<Target = T>> OrgBluezDevice1
     for nonblock::Proxy<'a, C>
 {
@@ -255,101 +351,5 @@ impl<'a, T: nonblock::NonblockReply, C: ::std::ops::Deref<Target = T>> OrgBluezD
             "Blocked",
             value,
         )
-    }
-}
-
-pub const ORG_BLUEZ_DEVICE1_NAME: &str = "org.bluez.Device1";
-
-#[derive(Copy, Clone, Debug)]
-pub struct OrgBluezDevice1Properties<'a>(pub &'a arg::PropMap);
-
-impl<'a> OrgBluezDevice1Properties<'a> {
-    pub fn from_interfaces(
-        interfaces: &'a ::std::collections::HashMap<String, arg::PropMap>,
-    ) -> Option<Self> {
-        interfaces.get("org.bluez.Device1").map(Self)
-    }
-
-    pub fn address(&self) -> Option<&String> {
-        arg::prop_cast(self.0, "Address")
-    }
-
-    pub fn address_type(&self) -> Option<&String> {
-        arg::prop_cast(self.0, "AddressType")
-    }
-
-    pub fn name(&self) -> Option<&String> {
-        arg::prop_cast(self.0, "Name")
-    }
-
-    pub fn alias(&self) -> Option<&String> {
-        arg::prop_cast(self.0, "Alias")
-    }
-
-    pub fn class(&self) -> Option<u32> {
-        arg::prop_cast(self.0, "Class").copied()
-    }
-
-    pub fn appearance(&self) -> Option<u16> {
-        arg::prop_cast(self.0, "Appearance").copied()
-    }
-
-    pub fn icon(&self) -> Option<&String> {
-        arg::prop_cast(self.0, "Icon")
-    }
-
-    pub fn paired(&self) -> Option<bool> {
-        arg::prop_cast(self.0, "Paired").copied()
-    }
-
-    pub fn trusted(&self) -> Option<bool> {
-        arg::prop_cast(self.0, "Trusted").copied()
-    }
-
-    pub fn blocked(&self) -> Option<bool> {
-        arg::prop_cast(self.0, "Blocked").copied()
-    }
-
-    pub fn legacy_pairing(&self) -> Option<bool> {
-        arg::prop_cast(self.0, "LegacyPairing").copied()
-    }
-
-    pub fn rssi(&self) -> Option<i16> {
-        arg::prop_cast(self.0, "RSSI").copied()
-    }
-
-    pub fn connected(&self) -> Option<bool> {
-        arg::prop_cast(self.0, "Connected").copied()
-    }
-
-    pub fn uuids(&self) -> Option<&Vec<String>> {
-        arg::prop_cast(self.0, "UUIDs")
-    }
-
-    pub fn modalias(&self) -> Option<&String> {
-        arg::prop_cast(self.0, "Modalias")
-    }
-
-    pub fn adapter(&self) -> Option<&dbus::Path<'static>> {
-        arg::prop_cast(self.0, "Adapter")
-    }
-
-    pub fn manufacturer_data(
-        &self,
-    ) -> Option<&::std::collections::HashMap<u16, arg::Variant<Box<dyn arg::RefArg + 'static>>>>
-    {
-        arg::prop_cast(self.0, "ManufacturerData")
-    }
-
-    pub fn service_data(&self) -> Option<&arg::PropMap> {
-        arg::prop_cast(self.0, "ServiceData")
-    }
-
-    pub fn tx_power(&self) -> Option<i16> {
-        arg::prop_cast(self.0, "TxPower").copied()
-    }
-
-    pub fn services_resolved(&self) -> Option<bool> {
-        arg::prop_cast(self.0, "ServicesResolved").copied()
     }
 }

--- a/bluez-generated/src/gattcharacteristic1.rs
+++ b/bluez-generated/src/gattcharacteristic1.rs
@@ -19,6 +19,47 @@ pub trait OrgBluezGattCharacteristic1 {
     fn notify_acquired(&self) -> nonblock::MethodReply<bool>;
 }
 
+pub const ORG_BLUEZ_GATT_CHARACTERISTIC1_NAME: &str = "org.bluez.GattCharacteristic1";
+
+#[derive(Copy, Clone, Debug)]
+pub struct OrgBluezGattCharacteristic1Properties<'a>(pub &'a arg::PropMap);
+
+impl<'a> OrgBluezGattCharacteristic1Properties<'a> {
+    pub fn from_interfaces(
+        interfaces: &'a ::std::collections::HashMap<String, arg::PropMap>,
+    ) -> Option<Self> {
+        interfaces.get("org.bluez.GattCharacteristic1").map(Self)
+    }
+
+    pub fn uuid(&self) -> Option<&String> {
+        arg::prop_cast(self.0, "UUID")
+    }
+
+    pub fn service(&self) -> Option<&dbus::Path<'static>> {
+        arg::prop_cast(self.0, "Service")
+    }
+
+    pub fn value(&self) -> Option<&Vec<u8>> {
+        arg::prop_cast(self.0, "Value")
+    }
+
+    pub fn notifying(&self) -> Option<bool> {
+        arg::prop_cast(self.0, "Notifying").copied()
+    }
+
+    pub fn flags(&self) -> Option<&Vec<String>> {
+        arg::prop_cast(self.0, "Flags")
+    }
+
+    pub fn write_acquired(&self) -> Option<bool> {
+        arg::prop_cast(self.0, "WriteAcquired").copied()
+    }
+
+    pub fn notify_acquired(&self) -> Option<bool> {
+        arg::prop_cast(self.0, "NotifyAcquired").copied()
+    }
+}
+
 impl<'a, T: nonblock::NonblockReply, C: ::std::ops::Deref<Target = T>> OrgBluezGattCharacteristic1
     for nonblock::Proxy<'a, C>
 {
@@ -105,46 +146,5 @@ impl<'a, T: nonblock::NonblockReply, C: ::std::ops::Deref<Target = T>> OrgBluezG
             "org.bluez.GattCharacteristic1",
             "NotifyAcquired",
         )
-    }
-}
-
-pub const ORG_BLUEZ_GATT_CHARACTERISTIC1_NAME: &str = "org.bluez.GattCharacteristic1";
-
-#[derive(Copy, Clone, Debug)]
-pub struct OrgBluezGattCharacteristic1Properties<'a>(pub &'a arg::PropMap);
-
-impl<'a> OrgBluezGattCharacteristic1Properties<'a> {
-    pub fn from_interfaces(
-        interfaces: &'a ::std::collections::HashMap<String, arg::PropMap>,
-    ) -> Option<Self> {
-        interfaces.get("org.bluez.GattCharacteristic1").map(Self)
-    }
-
-    pub fn uuid(&self) -> Option<&String> {
-        arg::prop_cast(self.0, "UUID")
-    }
-
-    pub fn service(&self) -> Option<&dbus::Path<'static>> {
-        arg::prop_cast(self.0, "Service")
-    }
-
-    pub fn value(&self) -> Option<&Vec<u8>> {
-        arg::prop_cast(self.0, "Value")
-    }
-
-    pub fn notifying(&self) -> Option<bool> {
-        arg::prop_cast(self.0, "Notifying").copied()
-    }
-
-    pub fn flags(&self) -> Option<&Vec<String>> {
-        arg::prop_cast(self.0, "Flags")
-    }
-
-    pub fn write_acquired(&self) -> Option<bool> {
-        arg::prop_cast(self.0, "WriteAcquired").copied()
-    }
-
-    pub fn notify_acquired(&self) -> Option<bool> {
-        arg::prop_cast(self.0, "NotifyAcquired").copied()
     }
 }

--- a/bluez-generated/src/gattdescriptor1.rs
+++ b/bluez-generated/src/gattdescriptor1.rs
@@ -11,6 +11,31 @@ pub trait OrgBluezGattDescriptor1 {
     fn value(&self) -> nonblock::MethodReply<Vec<u8>>;
 }
 
+pub const ORG_BLUEZ_GATT_DESCRIPTOR1_NAME: &str = "org.bluez.GattDescriptor1";
+
+#[derive(Copy, Clone, Debug)]
+pub struct OrgBluezGattDescriptor1Properties<'a>(pub &'a arg::PropMap);
+
+impl<'a> OrgBluezGattDescriptor1Properties<'a> {
+    pub fn from_interfaces(
+        interfaces: &'a ::std::collections::HashMap<String, arg::PropMap>,
+    ) -> Option<Self> {
+        interfaces.get("org.bluez.GattDescriptor1").map(Self)
+    }
+
+    pub fn uuid(&self) -> Option<&String> {
+        arg::prop_cast(self.0, "UUID")
+    }
+
+    pub fn characteristic(&self) -> Option<&dbus::Path<'static>> {
+        arg::prop_cast(self.0, "Characteristic")
+    }
+
+    pub fn value(&self) -> Option<&Vec<u8>> {
+        arg::prop_cast(self.0, "Value")
+    }
+}
+
 impl<'a, T: nonblock::NonblockReply, C: ::std::ops::Deref<Target = T>> OrgBluezGattDescriptor1
     for nonblock::Proxy<'a, C>
 {
@@ -45,30 +70,5 @@ impl<'a, T: nonblock::NonblockReply, C: ::std::ops::Deref<Target = T>> OrgBluezG
             "org.bluez.GattDescriptor1",
             "Value",
         )
-    }
-}
-
-pub const ORG_BLUEZ_GATT_DESCRIPTOR1_NAME: &str = "org.bluez.GattDescriptor1";
-
-#[derive(Copy, Clone, Debug)]
-pub struct OrgBluezGattDescriptor1Properties<'a>(pub &'a arg::PropMap);
-
-impl<'a> OrgBluezGattDescriptor1Properties<'a> {
-    pub fn from_interfaces(
-        interfaces: &'a ::std::collections::HashMap<String, arg::PropMap>,
-    ) -> Option<Self> {
-        interfaces.get("org.bluez.GattDescriptor1").map(Self)
-    }
-
-    pub fn uuid(&self) -> Option<&String> {
-        arg::prop_cast(self.0, "UUID")
-    }
-
-    pub fn characteristic(&self) -> Option<&dbus::Path<'static>> {
-        arg::prop_cast(self.0, "Characteristic")
-    }
-
-    pub fn value(&self) -> Option<&Vec<u8>> {
-        arg::prop_cast(self.0, "Value")
     }
 }

--- a/bluez-generated/src/gattmanager1.rs
+++ b/bluez-generated/src/gattmanager1.rs
@@ -12,6 +12,8 @@ pub trait OrgBluezGattManager1 {
     fn unregister_application(&self, application: dbus::Path) -> nonblock::MethodReply<()>;
 }
 
+pub const ORG_BLUEZ_GATT_MANAGER1_NAME: &str = "org.bluez.GattManager1";
+
 impl<'a, T: nonblock::NonblockReply, C: ::std::ops::Deref<Target = T>> OrgBluezGattManager1
     for nonblock::Proxy<'a, C>
 {
@@ -35,5 +37,3 @@ impl<'a, T: nonblock::NonblockReply, C: ::std::ops::Deref<Target = T>> OrgBluezG
         )
     }
 }
-
-pub const ORG_BLUEZ_GATT_MANAGER1_NAME: &str = "org.bluez.GattManager1";

--- a/bluez-generated/src/gattservice1.rs
+++ b/bluez-generated/src/gattservice1.rs
@@ -10,6 +10,35 @@ pub trait OrgBluezGattService1 {
     fn includes(&self) -> nonblock::MethodReply<Vec<dbus::Path<'static>>>;
 }
 
+pub const ORG_BLUEZ_GATT_SERVICE1_NAME: &str = "org.bluez.GattService1";
+
+#[derive(Copy, Clone, Debug)]
+pub struct OrgBluezGattService1Properties<'a>(pub &'a arg::PropMap);
+
+impl<'a> OrgBluezGattService1Properties<'a> {
+    pub fn from_interfaces(
+        interfaces: &'a ::std::collections::HashMap<String, arg::PropMap>,
+    ) -> Option<Self> {
+        interfaces.get("org.bluez.GattService1").map(Self)
+    }
+
+    pub fn uuid(&self) -> Option<&String> {
+        arg::prop_cast(self.0, "UUID")
+    }
+
+    pub fn device(&self) -> Option<&dbus::Path<'static>> {
+        arg::prop_cast(self.0, "Device")
+    }
+
+    pub fn primary(&self) -> Option<bool> {
+        arg::prop_cast(self.0, "Primary").copied()
+    }
+
+    pub fn includes(&self) -> Option<&Vec<dbus::Path<'static>>> {
+        arg::prop_cast(self.0, "Includes")
+    }
+}
+
 impl<'a, T: nonblock::NonblockReply, C: ::std::ops::Deref<Target = T>> OrgBluezGattService1
     for nonblock::Proxy<'a, C>
 {
@@ -43,34 +72,5 @@ impl<'a, T: nonblock::NonblockReply, C: ::std::ops::Deref<Target = T>> OrgBluezG
             "org.bluez.GattService1",
             "Includes",
         )
-    }
-}
-
-pub const ORG_BLUEZ_GATT_SERVICE1_NAME: &str = "org.bluez.GattService1";
-
-#[derive(Copy, Clone, Debug)]
-pub struct OrgBluezGattService1Properties<'a>(pub &'a arg::PropMap);
-
-impl<'a> OrgBluezGattService1Properties<'a> {
-    pub fn from_interfaces(
-        interfaces: &'a ::std::collections::HashMap<String, arg::PropMap>,
-    ) -> Option<Self> {
-        interfaces.get("org.bluez.GattService1").map(Self)
-    }
-
-    pub fn uuid(&self) -> Option<&String> {
-        arg::prop_cast(self.0, "UUID")
-    }
-
-    pub fn device(&self) -> Option<&dbus::Path<'static>> {
-        arg::prop_cast(self.0, "Device")
-    }
-
-    pub fn primary(&self) -> Option<bool> {
-        arg::prop_cast(self.0, "Primary").copied()
-    }
-
-    pub fn includes(&self) -> Option<&Vec<dbus::Path<'static>>> {
-        arg::prop_cast(self.0, "Includes")
     }
 }

--- a/bluez-generated/src/healthmanager1.rs
+++ b/bluez-generated/src/healthmanager1.rs
@@ -11,6 +11,8 @@ pub trait OrgBluezHealthManager1 {
     fn destroy_application(&self, application: dbus::Path) -> nonblock::MethodReply<()>;
 }
 
+pub const ORG_BLUEZ_HEALTH_MANAGER1_NAME: &str = "org.bluez.HealthManager1";
+
 impl<'a, T: nonblock::NonblockReply, C: ::std::ops::Deref<Target = T>> OrgBluezHealthManager1
     for nonblock::Proxy<'a, C>
 {
@@ -30,5 +32,3 @@ impl<'a, T: nonblock::NonblockReply, C: ::std::ops::Deref<Target = T>> OrgBluezH
         )
     }
 }
-
-pub const ORG_BLUEZ_HEALTH_MANAGER1_NAME: &str = "org.bluez.HealthManager1";

--- a/bluez-generated/src/leadvertisingmanager1.rs
+++ b/bluez-generated/src/leadvertisingmanager1.rs
@@ -15,6 +15,31 @@ pub trait OrgBluezLEAdvertisingManager1 {
     fn supported_includes(&self) -> nonblock::MethodReply<Vec<String>>;
 }
 
+pub const ORG_BLUEZ_LEADVERTISING_MANAGER1_NAME: &str = "org.bluez.LEAdvertisingManager1";
+
+#[derive(Copy, Clone, Debug)]
+pub struct OrgBluezLEAdvertisingManager1Properties<'a>(pub &'a arg::PropMap);
+
+impl<'a> OrgBluezLEAdvertisingManager1Properties<'a> {
+    pub fn from_interfaces(
+        interfaces: &'a ::std::collections::HashMap<String, arg::PropMap>,
+    ) -> Option<Self> {
+        interfaces.get("org.bluez.LEAdvertisingManager1").map(Self)
+    }
+
+    pub fn active_instances(&self) -> Option<u8> {
+        arg::prop_cast(self.0, "ActiveInstances").copied()
+    }
+
+    pub fn supported_instances(&self) -> Option<u8> {
+        arg::prop_cast(self.0, "SupportedInstances").copied()
+    }
+
+    pub fn supported_includes(&self) -> Option<&Vec<String>> {
+        arg::prop_cast(self.0, "SupportedIncludes")
+    }
+}
+
 impl<'a, T: nonblock::NonblockReply, C: ::std::ops::Deref<Target = T>> OrgBluezLEAdvertisingManager1
     for nonblock::Proxy<'a, C>
 {
@@ -60,30 +85,5 @@ impl<'a, T: nonblock::NonblockReply, C: ::std::ops::Deref<Target = T>> OrgBluezL
             "org.bluez.LEAdvertisingManager1",
             "SupportedIncludes",
         )
-    }
-}
-
-pub const ORG_BLUEZ_LEADVERTISING_MANAGER1_NAME: &str = "org.bluez.LEAdvertisingManager1";
-
-#[derive(Copy, Clone, Debug)]
-pub struct OrgBluezLEAdvertisingManager1Properties<'a>(pub &'a arg::PropMap);
-
-impl<'a> OrgBluezLEAdvertisingManager1Properties<'a> {
-    pub fn from_interfaces(
-        interfaces: &'a ::std::collections::HashMap<String, arg::PropMap>,
-    ) -> Option<Self> {
-        interfaces.get("org.bluez.LEAdvertisingManager1").map(Self)
-    }
-
-    pub fn active_instances(&self) -> Option<u8> {
-        arg::prop_cast(self.0, "ActiveInstances").copied()
-    }
-
-    pub fn supported_instances(&self) -> Option<u8> {
-        arg::prop_cast(self.0, "SupportedInstances").copied()
-    }
-
-    pub fn supported_includes(&self) -> Option<&Vec<String>> {
-        arg::prop_cast(self.0, "SupportedIncludes")
     }
 }

--- a/bluez-generated/src/media1.rs
+++ b/bluez-generated/src/media1.rs
@@ -18,6 +18,8 @@ pub trait OrgBluezMedia1 {
     fn unregister_player(&self, player: dbus::Path) -> nonblock::MethodReply<()>;
 }
 
+pub const ORG_BLUEZ_MEDIA1_NAME: &str = "org.bluez.Media1";
+
 impl<'a, T: nonblock::NonblockReply, C: ::std::ops::Deref<Target = T>> OrgBluezMedia1
     for nonblock::Proxy<'a, C>
 {
@@ -49,5 +51,3 @@ impl<'a, T: nonblock::NonblockReply, C: ::std::ops::Deref<Target = T>> OrgBluezM
         self.method_call("org.bluez.Media1", "UnregisterPlayer", (player,))
     }
 }
-
-pub const ORG_BLUEZ_MEDIA1_NAME: &str = "org.bluez.Media1";

--- a/bluez-generated/src/networkserver1.rs
+++ b/bluez-generated/src/networkserver1.rs
@@ -8,6 +8,8 @@ pub trait OrgBluezNetworkServer1 {
     fn unregister(&self, uuid: &str) -> nonblock::MethodReply<()>;
 }
 
+pub const ORG_BLUEZ_NETWORK_SERVER1_NAME: &str = "org.bluez.NetworkServer1";
+
 impl<'a, T: nonblock::NonblockReply, C: ::std::ops::Deref<Target = T>> OrgBluezNetworkServer1
     for nonblock::Proxy<'a, C>
 {
@@ -19,5 +21,3 @@ impl<'a, T: nonblock::NonblockReply, C: ::std::ops::Deref<Target = T>> OrgBluezN
         self.method_call("org.bluez.NetworkServer1", "Unregister", (uuid,))
     }
 }
-
-pub const ORG_BLUEZ_NETWORK_SERVER1_NAME: &str = "org.bluez.NetworkServer1";

--- a/bluez-generated/src/profilemanager1.rs
+++ b/bluez-generated/src/profilemanager1.rs
@@ -13,6 +13,8 @@ pub trait OrgBluezProfileManager1 {
     fn unregister_profile(&self, profile: dbus::Path) -> nonblock::MethodReply<()>;
 }
 
+pub const ORG_BLUEZ_PROFILE_MANAGER1_NAME: &str = "org.bluez.ProfileManager1";
+
 impl<'a, T: nonblock::NonblockReply, C: ::std::ops::Deref<Target = T>> OrgBluezProfileManager1
     for nonblock::Proxy<'a, C>
 {
@@ -33,5 +35,3 @@ impl<'a, T: nonblock::NonblockReply, C: ::std::ops::Deref<Target = T>> OrgBluezP
         self.method_call("org.bluez.ProfileManager1", "UnregisterProfile", (profile,))
     }
 }
-
-pub const ORG_BLUEZ_PROFILE_MANAGER1_NAME: &str = "org.bluez.ProfileManager1";


### PR DESCRIPTION
Bump `actions/checkout` and `actions/cache` to v3
Bump `dbus-codegen` to 0.10.0
Bump `codecov/codecov-action` to v3 (v1 is now [deprecated](https://github.com/codecov/codecov-action#%EF%B8%8F--deprecation-of-v1))