### PR TITLE
Drop async-trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,17 +27,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-trait"
-version = "0.1.82"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "backtrace"
 version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -68,7 +57,6 @@ checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 name = "bluez-async"
 version = "0.7.2"
 dependencies = [
- "async-trait",
  "bitflags 2.6.0",
  "bluez-generated",
  "dbus",

--- a/bluez-async/Cargo.toml
+++ b/bluez-async/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "bluez-async"
 version = "0.7.2"
-authors = ["Andrew Walbran <qwandor@google.com>", "David Laban <alsuren@gmail.com>"]
+authors = [
+  "Andrew Walbran <qwandor@google.com>",
+  "David Laban <alsuren@gmail.com>",
+]
 edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "An async wrapper around the D-Bus interface of BlueZ (the Linux Bluetooth daemon), supporting GATT client (central) functionality."
@@ -10,7 +13,6 @@ keywords = ["ble", "bluetooth", "bluez"]
 categories = ["api-bindings", "hardware-support", "os::linux-apis"]
 
 [dependencies]
-async-trait = "0.1.82"
 bitflags = "2.6.0"
 bluez-generated = { version = "0.3.0", path = "../bluez-generated" }
 dbus = { version = "0.9.7", features = ["futures"] }
@@ -27,4 +29,9 @@ uuid = "1.10.0"
 [dev-dependencies]
 eyre = "0.6.12"
 pretty_env_logger = "0.5.0"
-tokio = { version = "1.38.1", features = ["macros", "rt", "rt-multi-thread", "time"] }
+tokio = { version = "1.38.1", features = [
+  "macros",
+  "rt",
+  "rt-multi-thread",
+  "time",
+] }

--- a/bluez-async/src/introspect.rs
+++ b/bluez-async/src/introspect.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use dbus::nonblock::stdintf::org_freedesktop_dbus::Introspectable;
 use serde::Deserialize;
 
@@ -109,12 +108,10 @@ pub enum Access {
 }
 
 /// Extension trait to introspect D-Bus objects and parse the resulting XML into a typed structure.
-#[async_trait]
 pub trait IntrospectParse {
     async fn introspect_parse(&self) -> Result<Node, BluetoothError>;
 }
 
-#[async_trait]
 impl<T: Introspectable + Sync> IntrospectParse for T {
     /// Introspect this object, and parse the resulting XML into a typed structure.
     async fn introspect_parse(&self) -> Result<Node, BluetoothError> {


### PR DESCRIPTION
This is a preview and in anticipation of Rust 1.75. But it works well with current nightly either.